### PR TITLE
fix typo

### DIFF
--- a/articles/60b5636ed037e9.md
+++ b/articles/60b5636ed037e9.md
@@ -75,7 +75,7 @@ https://github.com/NULL-header/assert-parse
 
 fixtureとして渡されたassertに対して、メソッドコールの形でアサートするのが最もベーシックな使い方です。
 
-## Shorthund
+## Shorthand
 
 ユーティリティのマクロを利用することで、このユーティリティを用いる上でのボイラーテンプレートを省略することもできます。
 


### PR DESCRIPTION
s/shorthund/shorthand/